### PR TITLE
Remove car_service_center table creation

### DIFF
--- a/src/main/java/com/fixmycar/model/Car.java
+++ b/src/main/java/com/fixmycar/model/Car.java
@@ -8,8 +8,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
@@ -44,12 +42,8 @@ public class Car {
     @JsonIgnoreProperties({"car", "customer", "serviceCenter"})
     private List<ServiceRequest> serviceRequests = new ArrayList<>();
 
-    @ManyToMany(fetch = FetchType.EAGER)
-    @JoinTable(
-            name = "car_service_center",
-            joinColumns = @JoinColumn(name = "car_id"),
-            inverseJoinColumns = @JoinColumn(name = "service_center_id")
-    )
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "service_center_id")
     @JsonIgnoreProperties({"cars", "serviceRequests"})
-    private List<ServiceCenter> serviceCenters = new ArrayList<>();
+    private ServiceCenter serviceCenter;
 }


### PR DESCRIPTION
This pull request modifies the Car entity to eliminate the creation of the `car_service_center` table. The relationship between `Car` and `ServiceCenter` has been changed from a many-to-many relationship to a many-to-one relationship. This change simplifies the data model by allowing each car to be associated with a single service center, thus removing the need for the join table. The `serviceCenters` list has been replaced with a single `serviceCenter` reference.

---

> This pull request was co-created with Cosine Genie

Original Task: [FixMyCar/0his0wvn5cd6](https://cosine.sh/c37vjhwnl6v8/FixMyCar/task/0his0wvn5cd6)
Author: Dima Chehovich
